### PR TITLE
Change event id to avoid overwrite

### DIFF
--- a/src/handlers/executors/contribution.ts
+++ b/src/handlers/executors/contribution.ts
@@ -17,7 +17,7 @@ export const handleContributed = async ({
     data.toString()
   ) as [number, number[], string, string, string]
   const contributionRecord = Contribution.create({
-    id: idx.toString(),
+    id: `${extrinsic.extrinsic.hash.toString()}-${idx}`,
     extrinsicHash: extrinsic.extrinsic.hash.toString(),
     vaultId: aggregateIntoId(
       paraId.toString(),


### PR DESCRIPTION
Due to the `idx` is the event index. It maybe same for different event.
